### PR TITLE
Add eslint checking before pull request

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -18,16 +18,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4.1.0
+
       - name: Install ESLint
         run: |
-          npm ci
-          npm install @microsoft/eslint-formatter-sarif
+          pnpm install --frozen-lockfile
+          pnpm install @microsoft/eslint-formatter-sarif
 
       - name: Run ESLint
         env:
           SARIF_ESLINT_IGNORE_SUPPRESSED: "true"
         run: |
-          npx eslint
+          pnpx eslint
           --format @microsoft/eslint-formatter-sarif
           --output-file eslint-results.sarif
         continue-on-error: true

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -26,15 +26,15 @@ jobs:
       - name: Run ESLint
         env:
           SARIF_ESLINT_IGNORE_SUPPRESSED: "true"
-        run: npx eslint .
-          --config .eslintrc.js
-          --ext .js,.jsx,.ts,.tsx
+        run: |
+          npx eslint .
           --format @microsoft/eslint-formatter-sarif
           --output-file eslint-results.sarif
         continue-on-error: true
 
       - name: Upload analysis results to GitHub
         uses: github/codeql-action/upload-sarif@v3
+        continue-on-error: true
         with:
           sarif_file: eslint-results.sarif
           wait-for-processing: true

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run ESLint
         env:
           SARIF_ESLINT_IGNORE_SUPPRESSED: "true"
-        run: |
+        run: >
           pnpx eslint
           --config ./eslint.config.mjs
           --format @microsoft/eslint-formatter-sarif

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -33,6 +33,7 @@ jobs:
           SARIF_ESLINT_IGNORE_SUPPRESSED: "true"
         run: |
           pnpx eslint
+          --config ./eslint.config.mjs
           --format @microsoft/eslint-formatter-sarif
           --output-file eslint-results.sarif
         continue-on-error: true

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           SARIF_ESLINT_IGNORE_SUPPRESSED: "true"
         run: >
-          pnpx eslint
+          pnpm exec eslint
           --config ./eslint.config.mjs
           --format @microsoft/eslint-formatter-sarif
           --output-file eslint-results.sarif

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           SARIF_ESLINT_IGNORE_SUPPRESSED: "true"
         run: |
-          npx eslint .
+          npx eslint
           --format @microsoft/eslint-formatter-sarif
           --output-file eslint-results.sarif
         continue-on-error: true

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,0 +1,40 @@
+name: ESLint
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  eslint:
+    name: Run eslint scanning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install ESLint
+        run: |
+          npm install eslint@8.10.0
+          npm install @microsoft/eslint-formatter-sarif@3.1.0
+
+      - name: Run ESLint
+        env:
+          SARIF_ESLINT_IGNORE_SUPPRESSED: "true"
+        run: npx eslint .
+          --config .eslintrc.js
+          --ext .js,.jsx,.ts,.tsx
+          --format @microsoft/eslint-formatter-sarif
+          --output-file eslint-results.sarif
+        continue-on-error: true
+
+      - name: Upload analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: eslint-results.sarif
+          wait-for-processing: true

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -20,8 +20,8 @@ jobs:
 
       - name: Install ESLint
         run: |
-          npm install eslint@8.10.0
-          npm install @microsoft/eslint-formatter-sarif@3.1.0
+          npm ci
+          npm install @microsoft/eslint-formatter-sarif
 
       - name: Run ESLint
         env:
@@ -34,7 +34,6 @@ jobs:
 
       - name: Upload analysis results to GitHub
         uses: github/codeql-action/upload-sarif@v3
-        continue-on-error: true
         with:
           sarif_file: eslint-results.sarif
           wait-for-processing: true

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 9.15.0
 
       - name: Install ESLint
         run: |


### PR DESCRIPTION
Added default github action to enable eslint checking before accepting pull requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated ESLint checks to CI for pushes to main and pull requests targeting main.
  * Generates SARIF-format lint reports and uploads them to the code scanning dashboard for processing.
  * Runs on Linux CI runners and installs required dependencies before linting.
  * Configured to respect suppressed findings and continue without failing the workflow on lint errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->