### PR TITLE
Fix login and add redirect

### DIFF
--- a/app/api/qr/route.ts
+++ b/app/api/qr/route.ts
@@ -9,7 +9,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "invalid_player" }, { status: 400 });
   }
 
-  const url = `${origin}/join/${player}`;
+  const url = `${origin}/join/${player}?redirect=/play/${player}`;
   const qrDataUrl = await QRCode.toDataURL(url);
 
   return NextResponse.json({ player, qr: qrDataUrl });

--- a/app/join/[player]/page.tsx
+++ b/app/join/[player]/page.tsx
@@ -1,79 +1,63 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useParams } from "next/navigation";
-import { toast } from "sonner";
-import { IconLoader2 } from "@tabler/icons-react";
-import { useRouter } from "next/navigation";
-import { SessionResult, SessionResultType } from "@/lib/session";
+import {useEffect} from "react";
+import {useParams, useRouter, useSearchParams} from "next/navigation";
+import {toast} from "sonner";
+import {IconLoader2} from "@tabler/icons-react";
+import {SessionResult} from "@/lib/session";
+
+let globalLoggingInFlag = false;
 
 export default function JoinPlayerPage() {
-  const router = useRouter();
-  const { player } = useParams<{ player: string }>();
-  const [alreadyLoggedIn, setAlreadyLoggedIn] = useState(false);
-  const [status, setStatus] = useState<SessionResultType|null>(null);
+    const router = useRouter();
+    const {player} = useParams<{ player: string }>();
+    const searchParams = useSearchParams();
+    const redirect = searchParams.get("redirect") ?? "/";
 
-  useEffect(() => {
-    if (player !== "player1" && player !== "player2") {
-      router.replace("/join/invalid");
-    }
-
-    if (status === "new_session" && player) {
-      router.replace(`/play/${player}`);
-    }
-  }, [status, player, router]);
-
-  useEffect(() => {
-    if (status === "new_session") {
-      if (!alreadyLoggedIn) {
-        toast.success("Successfully joined!");
-      }
-    } else if (status === "taken") {
-      toast.error("This player is already taken.");
-    } else if (status === "invalid_player") {
-      toast.error("Invalid player.");
-    } else if (status === "already_logged_in") {
-      toast.error("You are already logged in as the other player.");
-    }
-  }, [status, alreadyLoggedIn]);
-
-  useEffect(() => {
-    async function join() {
-      try {
-        const res = await fetch(`/api/join/${player}`);
-        const data = await res.json() as SessionResult;
-        if (data.type === "already_logged_in") {
-          setAlreadyLoggedIn(true);
+    useEffect(() => {
+        async function join() {
+            try {
+                globalLoggingInFlag = true;
+                const res = await fetch(`/api/join/${player}`);
+                const data = await res.json() as SessionResult;
+                switch (data.type) {
+                    case "new_session":
+                        toast.success("Successfully joined!");
+                        router.replace(redirect)
+                        break;
+                    case "already_logged_in":
+                        if (data.player === player) {
+                            toast.success("You are already logged in.");
+                            router.replace(redirect)
+                        } else {
+                            toast.error("You are already logged in as the other player.");
+                            router.replace("/");
+                        }
+                        break;
+                    case "invalid_player":
+                        toast.error("Invalid player.");
+                        router.replace("/");
+                        break;
+                    case "taken":
+                        toast.error("This player is already taken.");
+                        router.replace("/");
+                        break;
+                }
+            } catch {
+                toast.error("Failed to join the game. Please try again.");
+                router.replace("/");
+            } finally {
+                globalLoggingInFlag = false;
+            }
         }
-        setStatus(data.type);
-      } catch {
-        setStatus(null);
-      }
-    }
-    if (player) join();
-  }, [player]);
 
-  if (status == null) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-screen p-4">
-        <h1 className="text-2xl font-bold mb-4">Joining Tetris game...</h1>
-        <IconLoader2 stroke={2} className="animate-spin" />
-      </div>
-    );
-  }
-
-  if (status !== "new_session") {
-    let message = "Something went wrong.";
-    if (status === "taken") message = "This player is already taken.";
-    if (status === "invalid_player") message = "This player is invalid.";
-    if (status === "already_logged_in") message = "You are already logged in as the other player.";
+        if (!globalLoggingInFlag) join();
+    }, [player, redirect, router]);
 
     return (
-      <div className="flex flex-col items-center justify-center min-h-screen p-4">
-        <h1 className="text-2xl font-bold mb-4">{message}</h1>
-      </div>
+        <div className="flex flex-col items-center justify-center min-h-screen p-4">
+            <h1 className="text-2xl font-bold mb-4">Joining Tetris game...</h1>
+            <IconLoader2 stroke={2} className="animate-spin"/>
+        </div>
     );
-  }
-
-  return null;
 }

--- a/app/qr/page.tsx
+++ b/app/qr/page.tsx
@@ -22,7 +22,7 @@ export default function PlayerQRCodes() {
     <div className="flex gap-8">
       {player1QR && (
         <div className="flex flex-col items-center">
-          <Link href="/join/player1">
+          <Link href="/join/player1?redirect=/play/player1">
             <Image src={player1QR} width={200} height={200} alt="QR Player 1" />
           </Link>
           <p>Player 1</p>
@@ -30,7 +30,7 @@ export default function PlayerQRCodes() {
       )}
       {player2QR && (
         <div className="flex flex-col items-center">
-          <Link href="/join/player2">
+          <Link href="/join/player2?redirect=/play/player2">
             <Image src={player2QR} width={200} height={200} alt="QR Player 2" />
           </Link>
           <p>Player 2</p>

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -4,7 +4,7 @@ export const expiry_time = 1000 * 60 * 60 * 2; // 2 hours
 
 export type SessionResult =
     | { type: "invalid_player";}
-    | { type: "already_logged_in"; sessionId: string }
+    | { type: "already_logged_in"; player: PlayerKey }
     | { type: "taken" }
     | { type: "new_session"; sessionId: string; expiresAt: number };
 
@@ -15,8 +15,9 @@ export function tryJoin(player: PlayerKey, cookieSession?: string): SessionResul
         return { type: "invalid_player"};
     }
 
-    if (alreadyLoggedIn(cookieSession)) {
-        return { type: "already_logged_in", sessionId: cookieSession! };
+    const loggedInAs = alreadyLoggedIn(cookieSession);
+    if (loggedInAs) {
+        return { type: "already_logged_in", player: loggedInAs };
     }
 
     if (isPlayerTaken(player)) {
@@ -39,19 +40,19 @@ export function checkLogin(player: PlayerKey, cookieSession?: string) {
     return true;
 }
 
-function alreadyLoggedIn(cookieSession?: string) {
+function alreadyLoggedIn(cookieSession?: string): PlayerKey | null {
     const player1Session = getActivePlayer("player1");
     const player2Session = getActivePlayer("player2");
 
-    if (!cookieSession) return false;
+    if (!cookieSession) return null;
 
     if (player1Session?.sessionId === cookieSession) {
-        return true;
+        return "player1";
     }
     if (player2Session?.sessionId === cookieSession) {
-        return true;
+        return "player2";
     }
-    return false;
+    return null;
 }
 
 function isPlayerTaken(player: PlayerKey) {


### PR DESCRIPTION
Login now works, because I added a global client side flag that prevents concurrent login requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - QR codes and joystick links now route directly to the correct play screen after joining.
  - Streamlined join flow with a single loading view and clearer success/error toasts.

- Bug Fixes
  - Prevents duplicate join attempts from rapid taps or reloads.
  - Correctly handles “already logged in” cases with appropriate messaging and routing.
  - Consistent redirects to home on invalid or taken player scenarios and network errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->